### PR TITLE
feat: add active processing card + fix report status lifecycle and some frontend logics

### DIFF
--- a/api/app/api/v1/reports.py
+++ b/api/app/api/v1/reports.py
@@ -239,6 +239,9 @@ async def import_report_files(
     if not queued_jobs and not skipped_files:
         raise HTTPException(status_code=400, detail="No files to process")
 
+    # Mark report as actively importing (AI analysis kicked off)
+    ReportRepository.update_status(report_id, "importing")
+
     return {
         "success":       True,
         "report_id":     report_id,
@@ -438,8 +441,14 @@ async def get_report_status(
     analysis = AIExtractedContentRepository.get_by_report(report_id)
     
     # Determine overall status
-    if not files:
+    # If the user has explicitly triggered AI import, always treat as 'processing'
+    # regardless of individual file statuses (files may have completed OCR but AI analysis hasn't run yet)
+    if report.get("report_status") == "importing":
+        overall_status = "processing"
+    elif not files:
         overall_status = "empty"
+    elif all(f.get("processing_status", "pending") in ("pending", None) for f in files):
+        overall_status = "pending"
     elif all(f.get("processing_status") == "completed" for f in files) and analysis:
         overall_status = "completed"
     elif any(f.get("processing_status") == "failed" for f in files):

--- a/api/app/tasks/process_task.py
+++ b/api/app/tasks/process_task.py
@@ -357,9 +357,16 @@ def process_document_task(self, document_id: str, user_id: str):
         },
     )
 
-    # Check if all files for this report are completed; if so, update report_status to 'review'
+    # Only promote to 'review' if the user explicitly started AI analysis (report_status == 'importing').
+    # Reports in 'process' (files uploaded but analysis not triggered) must NOT auto-advance.
     all_files = list(db["original_files"].find({"report_id": ObjectId(report_id)}))
-    if all_files and all(f.get("processing_status") == "completed" for f in all_files):
+    report_doc = db["reports"].find_one({"_id": ObjectId(report_id)}, {"report_status": 1})
+    if (
+        all_files
+        and all(f.get("processing_status") == "completed" for f in all_files)
+        and report_doc
+        and report_doc.get("report_status") == "importing"
+    ):
         db["reports"].update_one(
             {"_id": ObjectId(report_id)},
             {"$set": {"report_status": "review", "updated_at": datetime.utcnow()}}

--- a/web_app/src/components/Upload.tsx
+++ b/web_app/src/components/Upload.tsx
@@ -476,6 +476,7 @@ export default function Upload() {
                   onUpload={handleFileUpload}
                   onDownload={handleDownload}
                   onNext={() => setCurrentStep(3)}
+                  onUploadOnly={() => navigate('/')}
                   onBack={() => setCurrentStep(1)}
                 />
               )}

--- a/web_app/src/components/dashboard/ActiveProcessingCard.tsx
+++ b/web_app/src/components/dashboard/ActiveProcessingCard.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { reportsApi } from '../../apis/report.api';
+import { ValuationReport } from '../../types';
+
+interface ActiveProcessingCardProps {
+    report: ValuationReport;
+    onComplete?: () => void;
+}
+
+interface FileStatus {
+    id: string;
+    name: string;
+    status: string;
+    error?: string;
+}
+
+export default function ActiveProcessingCard({ report, onComplete }: ActiveProcessingCardProps) {
+    const navigate = useNavigate();
+    const [progress, setProgress] = useState({ percentage: 0, completed: 0, total: 0 });
+    const [files, setFiles] = useState<FileStatus[]>([]);
+    // Start as null (unknown) — render nothing until first poll resolves
+    const [isProcessing, setIsProcessing] = useState<boolean | null>(null);
+    const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+    useEffect(() => {
+        const checkStatus = async () => {
+            try {
+                const statusData = await reportsApi.getReportStatus(report.id);
+                setProgress(statusData.progress);
+                setFiles(statusData.files || []);
+
+                if (statusData.status === 'processing') {
+                    setIsProcessing(true);
+                } else if (statusData.status === 'completed' && statusData.progress.percentage >= 100) {
+                    setIsProcessing(false);
+                    if (pollingRef.current) clearInterval(pollingRef.current);
+                    if (onComplete) onComplete();
+                } else {
+                    setIsProcessing(false);
+                    if (pollingRef.current) clearInterval(pollingRef.current);
+                }
+            } catch (error) {
+                console.error('Failed to get report status', error);
+                setIsProcessing(false);
+                if (pollingRef.current) clearInterval(pollingRef.current);
+            }
+        };
+
+        checkStatus();
+        pollingRef.current = setInterval(checkStatus, 3000);
+
+        return () => {
+            if (pollingRef.current) clearInterval(pollingRef.current);
+        };
+    }, [report.id, onComplete]);
+
+    // Find the file currently being actively processed
+    const activeFile = files.find(f =>
+        ['queued', 'processing', 'ocr_started', 'ocr_completed', 'translation_started', 'translation_completed'].includes(f.status)
+    ) || files.find(f => f.status !== 'completed' && f.status !== 'failed');
+
+    // null = still loading first poll; false = not processing — render nothing
+    if (isProcessing !== true) return null;
+
+    return (
+        <div
+            onClick={() => navigate(`/upload/${report.id}?step=process`)}
+            className="group cursor-pointer bg-white rounded-2xl border border-blue-100 p-6 shadow-md hover:shadow-xl hover:shadow-blue-200/40 hover:border-blue-200 transition-all duration-300 relative overflow-hidden"
+        >
+            <div className="flex justify-between items-start mb-4">
+                <div className="min-w-0 flex-1 mr-3">
+                    <h3 className="text-lg font-bold text-slate-900 group-hover:text-blue-600 transition-colors line-clamp-1">
+                        {report.customerName}
+                    </h3>
+                    <p className="text-sm font-semibold text-blue-500 mt-1 uppercase tracking-wide">
+                        Processing AI Analysis...
+                    </p>
+                </div>
+                <div className="bg-blue-50 text-blue-600 px-3 py-1 rounded-full text-xs font-bold shrink-0">
+                    {Math.round(progress.percentage)}%
+                </div>
+            </div>
+
+            {/* Currently processing file name */}
+            {activeFile && (
+                <div className="flex items-center gap-2 mb-3 px-3 py-2 bg-blue-50/60 rounded-lg">
+                    <div className="w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse shrink-0" />
+                    <p className="text-xs text-blue-700 font-medium truncate">
+                        {activeFile.name}
+                    </p>
+                </div>
+            )}
+
+            <div className="space-y-2 w-full">
+                <div className="h-2.5 w-full bg-slate-100 rounded-full overflow-hidden">
+                    <div
+                        className="h-full bg-gradient-to-r from-blue-500 to-blue-600 rounded-full transition-all duration-500 ease-out relative"
+                        style={{ width: `${progress.percentage}%` }}
+                    >
+                        <div className="absolute top-0 right-0 bottom-0 left-0 bg-white/20 animate-pulse" />
+                    </div>
+                </div>
+                {progress.total > 0 && (
+                    <div className="text-xs font-medium text-slate-400 text-right">
+                        {progress.completed} of {progress.total} files analyzed
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/web_app/src/components/upload/ProcessingStep.tsx
+++ b/web_app/src/components/upload/ProcessingStep.tsx
@@ -44,13 +44,29 @@ export default function ProcessingStep({
                         <Loader2 size={32} className="text-brand-600 animate-spin" />
                     </div>
                     <h2 className="text-2xl font-bold text-slate-900 mb-2 tracking-tight">Processing Documents</h2>
-                    <p className="text-slate-500 text-sm mb-6 max-w-md mx-auto font-medium">
+                    <p className="text-slate-500 text-sm mb-4 max-w-md mx-auto font-medium">
                         Our AI is analyzing{' '}
                         <span className="font-bold text-brand-600 underline decoration-brand-200 decoration-2 underline-offset-4">
                             {selectedFiles.length} {selectedFiles.length === 1 ? 'file' : 'files'}
                         </span>
                         . This might take a moment.
                     </p>
+
+                    {/* Currently processing file banner */}
+                    {(() => {
+                        const activeFile = files
+                            .filter(f => selectedFiles.includes(f.id))
+                            .find(f => (f.progress ?? 0) < 100);
+                        return activeFile ? (
+                            <div className="flex items-center justify-center gap-2 mb-5 px-4 py-2.5 bg-brand-50 border border-brand-100 rounded-xl max-w-sm mx-auto">
+                                <span className="w-2 h-2 rounded-full bg-brand-500 animate-pulse shrink-0" />
+                                <p className="text-xs font-semibold text-brand-700 truncate">
+                                    <span className="text-brand-400 font-medium mr-1">Analyzing:</span>
+                                    {activeFile.name || activeFile.file?.name}
+                                </p>
+                            </div>
+                        ) : null;
+                    })()}
 
                     {/* Overall progress bar */}
                     <div className="mb-6 space-y-2">
@@ -72,8 +88,8 @@ export default function ProcessingStep({
                             id="processing-copy-link-btn"
                             onClick={handleCopy}
                             className={`flex items-center gap-2 px-5 py-2.5 rounded-xl border font-semibold hover:scale-[1.03] transition-all duration-200 text-sm ${copied
-                                    ? 'bg-emerald-500 border-emerald-500 text-white shadow-md scale-105'
-                                    : 'border-slate-200 text-slate-700 hover:bg-slate-50'
+                                ? 'bg-emerald-500 border-emerald-500 text-white shadow-md scale-105'
+                                : 'border-slate-200 text-slate-700 hover:bg-slate-50'
                                 }`}
                         >
                             {copied ? (

--- a/web_app/src/components/upload/UploadStep.tsx
+++ b/web_app/src/components/upload/UploadStep.tsx
@@ -15,6 +15,7 @@ interface UploadStepProps {
   onFilesChange: (files: UploadedFile[]) => void;
   onUpload: (files: File[]) => void;
   onNext: () => void;
+  onUploadOnly: () => void;
   onBack: () => void;
   onDownload: (file: UploadedFile) => void;
 }
@@ -25,6 +26,8 @@ export default function UploadStep({
   onFilesChange,
   onUpload,
   onNext,
+  onUploadOnly,
+  onBack,
   onDownload
 }: UploadStepProps) {
   const [dragActive, setDragActive] = useState(false);
@@ -242,18 +245,31 @@ export default function UploadStep({
           )}
 
           {files.length > 0 && (
-            <button
-              onClick={onNext}
-              className="w-full mt-6 py-3 rounded-lg
-              bg-gradient-to-r from-blue-600 to-blue-700
-              hover:from-blue-700 hover:to-blue-800
-              text-white font-semibold
-              flex items-center justify-center gap-2
-              shadow-md hover:shadow-lg transition"
-            >
-              Continue
-              <ArrowRight size={16} />
-            </button>
+            <div className="mt-6 flex flex-col gap-3">
+              <button
+                onClick={onUploadOnly}
+                className="w-full py-3 rounded-lg
+                bg-gradient-to-r from-blue-600 to-blue-700
+                hover:from-blue-700 hover:to-blue-800
+                text-white font-semibold
+                flex items-center justify-center gap-2
+                shadow-md hover:shadow-lg transition"
+              >
+                Upload
+              </button>
+              <button
+                onClick={onNext}
+                className="w-full py-3 rounded-lg
+                bg-gradient-to-r from-blue-600 to-blue-700
+                hover:from-blue-700 hover:to-blue-800
+                text-white font-semibold
+                flex items-center justify-center gap-2
+                shadow-md hover:shadow-lg transition"
+              >
+                Upload & Continue
+                <ArrowRight size={16} />
+              </button>
+            </div>
           )}
         </div>
       </div>

--- a/web_app/src/hooks/useReports.ts
+++ b/web_app/src/hooks/useReports.ts
@@ -34,10 +34,11 @@ export function useCreateReport() {
  * Get all reports
  * GET /api/v1/reports
  */
-export function useReports() {
+export function useReports(options?: { refetchInterval?: number }) {
   return useQuery({
     queryKey: REPORTS_KEY,
     queryFn: reportsApi.getReports,
+    ...(options?.refetchInterval ? { refetchInterval: options.refetchInterval } : {}),
   });
 }
 

--- a/web_app/src/pages/DashboardPage.tsx
+++ b/web_app/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import {
     FileText,
     Clock,
@@ -6,21 +6,22 @@ import {
     FileSearch,
     Upload,
     TrendingUp,
-    ArrowRight,
-    Search,
-    Filter
-} from 'lucide-react';
+    ArrowRight
+}
+
+    from 'lucide-react';
 import { DashboardStats, ValuationReport, ReportStatus, PropertyType } from '../types';
 import { formatDate } from '../utils/formatDate';
 import { mockDashboardStats } from '../data/mockData';
 import { useNavigate } from "react-router-dom";
 import { useReports } from '../hooks/useReports';
 import { ApiReport } from '../apis/report.api';
+import ActiveProcessingCard from '../components/dashboard/ActiveProcessingCard';
 
 export default function DashboardPage() {
-    const { data: reportsData, isLoading } = useReports();
+    // Poll every 5s so importing status cards appear/disappear without manual refresh
+    const { data: reportsData, isLoading } = useReports({ refetchInterval: 5000 });
     const navigate = useNavigate();
-    const [searchQuery, setSearchQuery] = useState('');
 
     const handleReportClick = (report: ValuationReport) => {
         switch (report.status) {
@@ -82,19 +83,32 @@ export default function DashboardPage() {
                 auditTrail: [],
             }));
 
-        if (searchQuery.trim()) {
-            const query = searchQuery.toLowerCase();
-            mappedReports = mappedReports.filter((report: ValuationReport) =>
-                report.customerName.toLowerCase().includes(query) ||
-                report.bankName.toLowerCase().includes(query) ||
-                report.propertyType.toLowerCase().includes(query) ||
-                report.status.toLowerCase().includes(query) ||
-                report.location.toLowerCase().includes(query)
-            );
-        }
-
         return mappedReports;
-    }, [reportsData, searchQuery]);
+    }, [reportsData]);
+
+    const processingReports: ValuationReport[] = useMemo(() => {
+        if (!reportsData?.reports) return [];
+
+        return reportsData.reports
+            .filter((r: ApiReport) => (r.report_status || r.status || '').toLowerCase() === 'importing')
+            .map((r: ApiReport) => ({
+                id: r.id,
+                customerName: (r as any).report_name || r.customer_name || r.name || (r as any).property_owner || r.bank_name || 'Untitled Report',
+                bankName: r.bank_name || 'Unknown Bank',
+                propertyType: (r.property_type as PropertyType) || 'Residential',
+                location: r.location || 'Unknown Location',
+                status: 'process',
+                createdAt: new Date(r.created_at),
+                updatedAt: new Date(r.updated_at),
+                year: new Date(r.created_at).getFullYear().toString(),
+                month: (new Date(r.created_at).getMonth() + 1).toString().padStart(2, '0'),
+                files: [],
+                metadata: {} as any,
+                content: {} as any,
+                comments: [],
+                auditTrail: [],
+            }));
+    }, [reportsData]);
 
     const statCards = [
         {
@@ -106,7 +120,7 @@ export default function DashboardPage() {
             border: 'border-brand-200',
             circleBg: 'bg-brand-300',
             trendColor: 'bg-brand-100 text-brand-700',
-            trend: 'All Reports',
+            trend: 'All generated reports',
             path: '/list'
         },
         {
@@ -118,7 +132,7 @@ export default function DashboardPage() {
             border: 'border-amber-200',
             circleBg: 'bg-amber-300',
             trendColor: 'bg-amber-100 text-amber-700',
-            trend: 'Upload',
+            trend: 'Awaiting file uploads',
             path: '/list?status=draft'
         },
         {
@@ -130,7 +144,7 @@ export default function DashboardPage() {
             border: 'border-blue-200',
             circleBg: 'bg-blue-300',
             trendColor: 'bg-blue-100 text-blue-700',
-            trend: 'In Progress',
+            trend: 'Ready for AI analysis',
             path: '/list?status=process'
         },
         {
@@ -142,7 +156,7 @@ export default function DashboardPage() {
             border: 'border-orange-200',
             circleBg: 'bg-orange-300',
             trendColor: 'bg-orange-100 text-orange-700',
-            trend: 'Pending',
+            trend: 'Pending your approval',
             path: '/list?status=review'
         },
         {
@@ -154,7 +168,7 @@ export default function DashboardPage() {
             border: 'border-emerald-200',
             circleBg: 'bg-emerald-300',
             trendColor: 'bg-emerald-100 text-emerald-700',
-            trend: 'Verified',
+            trend: 'Finalized reports',
             path: '/list?status=approved'
         },
     ];
@@ -244,19 +258,6 @@ export default function DashboardPage() {
                     <p className="text-slate-600 font-semibold mt-1">Overview of valuation reports and system activity</p>
                 </div>
                 <div className="flex items-center gap-3">
-                    <div className="relative group">
-                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 group-focus-within:text-brand-500 transition-colors" size={18} />
-                        <input
-                            type="text"
-                            value={searchQuery}
-                            onChange={(e) => setSearchQuery(e.target.value)}
-                            placeholder="Search reports..."
-                            className="pl-10 pr-4 py-2.5 bg-white border border-brand-200 rounded-xl text-base focus:ring-4 focus:ring-brand-500/10 focus:border-brand-500 outline-none w-80 shadow-sm transition-all font-medium text-slate-900 placeholder:text-slate-400"
-                        />
-                    </div>
-                    <button className="p-2.5 bg-white border border-brand-200 rounded-xl text-brand-600 hover:bg-brand-50 transition-all shadow-sm">
-                        <Filter size={20} />
-                    </button>
                     <button
                         onClick={() => navigate('upload')}
                         className="bg-gradient-to-r from-brand-700 to-brand-900 hover:from-brand-800 hover:to-brand-950 text-white px-6 py-2.5 rounded-xl text-base font-bold flex items-center gap-2 shadow-lg shadow-brand-300/40 transition-all hover:-translate-y-0.5"
@@ -293,6 +294,15 @@ export default function DashboardPage() {
                     </div>
                 ))}
             </div>
+
+            {/* Processing State - Only visible when reports are in process state */}
+            {processingReports.length > 0 && (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {processingReports.map((report) => (
+                        <ActiveProcessingCard key={`processing-${report.id}`} report={report} />
+                    ))}
+                </div>
+            )}
 
             {/* Main Section */}
             <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">


### PR DESCRIPTION

<img width="1599" height="791" alt="image" src="https://github.com/user-attachments/assets/a32265df-bb40-48b5-a5aa-48e1d8605267" />


Dashboard:
- Add ActiveProcessingCard component with 3s polling, shows report name, currently-processing file (with pulsing dot), progress bar, and %
- Dashboard filters by 'importing' status (not 'process') to prevent false cards for reports with only uploaded files
- useReports polls every 5s on dashboard to pick up status changes

Upload wizard:
- Split "Continue" into "Upload" (→ dashboard) and "Upload & Continue" (→ select step)
- ProcessingStep shows "Analyzing: <filename>" banner above progress bar

Backend:
- POST /reports/{id}/import now sets report_status = 'importing' to distinguish AI-in-progress from files-uploaded-but-not-started
- GET /reports/{id}/status returns 'processing' when report_status = 'importing', regardless of file-level statuses (fixes OCR-complete-but-AI-not-started case)
- process_task.py only promotes report to 'review' when report_status = 'importing', preventing 'process' reports from auto-advancing on file completion