### PR TITLE
feat: extract history view to dedicated page, add pagination & search

### DIFF
--- a/api/app/api/v1/reports.py
+++ b/api/app/api/v1/reports.py
@@ -116,15 +116,33 @@ async def create_report(
 
 
 @router.get("/reports")
-async def get_reports(current_user: dict = Depends(get_current_user)):
-    """Get all reports for current user"""
+async def get_reports(
+    current_user: dict = Depends(get_current_user),
+    page: int = Query(1, ge=1, description="Page number (1-based)"),
+    page_size: int = Query(10, ge=1, le=100, description="Number of items per page"),
+    search: Optional[str] = Query(None, description="Search term for report name or bank name"),
+):
+    """Get paginated reports for current user"""
+
+    skip = (page - 1) * page_size
+    search_term = search.strip() if search else None
 
     if "admin" in current_user.get("roles", []):
-        reports = ReportRepository.get_all()
+        total = ReportRepository.count_all(search=search_term)
+        report_list = ReportRepository.get_all(skip=skip, limit=page_size, search=search_term)
     else:
-        reports = ReportRepository.get_all(user_id=current_user["id"])
+        total = ReportRepository.count_all(user_id=current_user["id"], search=search_term)
+        report_list = ReportRepository.get_all(user_id=current_user["id"], skip=skip, limit=page_size, search=search_term)
 
-    return {"success": True, "reports": reports}
+    return {
+        "success": True,
+        "reports": report_list,
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "total_pages": max(1, -(-total // page_size)),  # ceiling division
+    }
+
 
 
 @router.get("/reports/check")

--- a/api/app/repositories/report_repo.py
+++ b/api/app/repositories/report_repo.py
@@ -64,13 +64,32 @@ class ReportRepository:
             return None
     
     @staticmethod
-    def get_all(user_id: str = None) -> list:
+    def count_all(user_id: str = None, search: str = None) -> int:
         query = {}
         if user_id:
             query["user_id"] = ObjectId(user_id)
+        if search:
+            import re
+            pattern = re.compile(re.escape(search), re.IGNORECASE)
+            query["$or"] = [{"report_name": pattern}, {"bank_name": pattern}]
+        return reports.count_documents(query)
+
+    @staticmethod
+    def get_all(user_id: str = None, skip: int = 0, limit: int = 0, search: str = None) -> list:
+        query = {}
+        if user_id:
+            query["user_id"] = ObjectId(user_id)
+        if search:
+            import re
+            pattern = re.compile(re.escape(search), re.IGNORECASE)
+            query["$or"] = [{"report_name": pattern}, {"bank_name": pattern}]
+
+        cursor = reports.find(query).sort("updated_at", -1).skip(skip)
+        if limit > 0:
+            cursor = cursor.limit(limit)
 
         result = []
-        for report in reports.find(query):
+        for report in cursor:
             report_id = str(report["_id"])
             files = OriginalFileRepository.get_by_report(report_id)
             
@@ -87,6 +106,7 @@ class ReportRepository:
             result.append(item)
 
         return result
+
         
     @staticmethod
     def update_name(report_id: str, report_name: str, updated_by: str) -> Optional[dict]:

--- a/web_app/src/apis/report.api.ts
+++ b/web_app/src/apis/report.api.ts
@@ -29,6 +29,10 @@ export interface ApiReport {
 
 export interface GetReportsResponse {
   reports: ApiReport[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
 }
 
 export interface CheckReportNameResponse {
@@ -56,8 +60,11 @@ export const reportsApi = {
    * Get all reports
    * GET /api/v1/reports
    */
-  getReports: () =>
-    apiClient.get<GetReportsResponse>('/api/v1/reports'),
+  getReports: (page = 1, page_size = 10, search?: string) => {
+    const params = new URLSearchParams({ page: String(page), page_size: String(page_size) });
+    if (search) params.set('search', search);
+    return apiClient.get<GetReportsResponse>(`/api/v1/reports?${params.toString()}`);
+  },
 
   /**
    * Check report name availability

--- a/web_app/src/app/router.tsx
+++ b/web_app/src/app/router.tsx
@@ -14,6 +14,7 @@ import SignupPage from "../pages/SignupPage";
 import ProcessingPage from "../pages/ProcessingPage";
 import ReportListPage from "../pages/ReportListPage";
 import CurrentReportPage from "../pages/CurrentReportPage";
+import HistoryPage from "../pages/HistoryPage";
 
 // Placeholder components for missing files
 const ErrorBoundary = () => (
@@ -58,6 +59,7 @@ const router = createBrowserRouter([
       { path: "users", element: <UsersPage /> },
       { path: "banks", element: <BankManagementPage /> },
       { path: "list", element: <ReportListPage /> },
+      { path: "history", element: <HistoryPage /> },
       { path: "current-report", element: <CurrentReportPage /> },
       { path: "*", element: <NotFound /> }, // Catch-all 404 route
     ],

--- a/web_app/src/components/Upload.tsx
+++ b/web_app/src/components/Upload.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import { LayoutGrid, History } from 'lucide-react';
 import { config } from '../config/config';
 
 // Components
@@ -10,9 +9,6 @@ import UploadStep from './upload/UploadStep';
 import FileSelectionStep from './upload/FileSelectionStep';
 import ProcessingStep from './upload/ProcessingStep';
 import CompletionStep from './upload/CompletionStep';
-import ReportsSidebar from './upload/ReportsSidebar';
-import ReportDetailView from './upload/ReportDetailView';
-
 // Types
 import { UploadedFile, ProjectReport } from './upload/types';
 
@@ -21,12 +17,9 @@ import { useCreateReport, useReport } from '../hooks/useReports';
 import { reportsApi } from '../apis/report.api';
 import { useAppStore } from '../store/useAppStore';
 
-type ViewMode = 'upload' | 'browse';
-
 export default function Upload() {
   // ==================== STATE ====================
 
-  const [viewMode, setViewMode] = useState<ViewMode>('upload');
   const [currentStep, setCurrentStep] = useState(1);
 
   const [projectName, setProjectName] = useState('');
@@ -40,7 +33,6 @@ export default function Upload() {
     percentage: 0,
   });
 
-  const [selectedBrowseReportId, setSelectedBrowseReportId] = useState<string | null>(null);
   const [recentProjects] = useState<ProjectReport[]>([]);
 
   // ==================== REFS ====================
@@ -418,118 +410,79 @@ export default function Upload() {
 
               {/* Step Indicator */}
               <div className="flex items-center justify-center w-full pt-4 lg:pt-8">
-                {viewMode === 'upload' && (
-                  <StepIndicator currentStep={currentStep} />
-                )}
+                <StepIndicator currentStep={currentStep} />
               </div>
 
-              {/* View Mode Toggle */}
-              <div className="flex justify-center lg:justify-end w-full">
-                <div className="flex gap-2 bg-sky-500 shadow-md shadow-sky-200 p-1 rounded-lg shrink-0">
-                  <button
-                    onClick={() => setViewMode('upload')}
-                    className={`px-4 py-2 rounded-md font-medium transition-all flex items-center gap-2 ${viewMode === 'upload'
-                      ? 'bg-white text-sky-600 shadow-sm'
-                      : 'text-white/80 hover:text-white'
-                      }`}
-                  >
-                    <LayoutGrid size={16} />
-                    Wizard
-                  </button>
-                  <button
-                    onClick={() => setViewMode('browse')}
-                    className={`px-4 py-2 rounded-md font-medium transition-all flex items-center gap-2 ${viewMode === 'browse'
-                      ? 'bg-white text-sky-600 shadow-sm'
-                      : 'text-white/80 hover:text-white'
-                      }`}
-                  >
-                    <History size={16} />
-                    History
-                  </button>
-                </div>
-              </div>
+              {/* Empty Right Placeholder to balance Grid */}
+              <div className="hidden lg:block"></div>
             </div>
           </div>
         </header>
 
         {/* Main Content */}
         <main className="flex-1 min-h-0 overflow-y-auto max-w-7xl w-full mx-auto px-2 sm:px-3 lg:px-4 py-8">
-          {viewMode === 'browse' ? (
-            <div className="grid grid-cols-1 lg:grid-cols-[380px_1fr] gap-6 min-h-full">
-              <div className="bg-white rounded-xl shadow-lg border border-slate-200 overflow-hidden flex flex-col min-h-0">
-                <ReportsSidebar
-                  selectedReportId={selectedBrowseReportId}
-                  onReportSelect={setSelectedBrowseReportId}
-                />
-              </div>
-              <div className="bg-white rounded-xl shadow-lg border border-slate-200 overflow-hidden flex flex-col min-h-0">
-                <ReportDetailView reportId={selectedBrowseReportId} />
-              </div>
-            </div>
-          ) : (
-            <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
-              {currentStep === 1 && (
-                <ProjectNameStep
-                  projectName={projectName}
-                  setProjectName={setProjectName}
-                  bankName={bankName}
-                  setBankName={setBankName}
-                  onNext={handleCreateReport}
-                  recentProjects={recentProjects}
-                />
-              )}
+          <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
+            {currentStep === 1 && (
+              <ProjectNameStep
+                projectName={projectName}
+                setProjectName={setProjectName}
+                bankName={bankName}
+                setBankName={setBankName}
+                onNext={handleCreateReport}
+                recentProjects={recentProjects}
+              />
+            )}
 
-              {currentStep === 2 && (
-                <UploadStep
-                  projectName={projectName}
-                  files={files}
-                  onFilesChange={setFiles}
-                  onUpload={handleFileUpload}
-                  onDownload={handleDownload}
-                  onNext={() => setCurrentStep(3)}
-                  onUploadOnly={() => navigate('/')}
-                  onBack={() => setCurrentStep(1)}
-                />
-              )}
+            {currentStep === 2 && (
+              <UploadStep
+                projectName={projectName}
+                files={files}
+                onFilesChange={setFiles}
+                onUpload={handleFileUpload}
+                onDownload={handleDownload}
+                onNext={() => setCurrentStep(3)}
+                onUploadOnly={() => navigate('/')}
+                onBack={() => setCurrentStep(1)}
+              />
+            )}
 
-              {currentStep === 3 && (
-                <FileSelectionStep
-                  files={files}
-                  selectedFiles={selectedFiles}
-                  setSelectedFiles={setSelectedFiles}
-                  onFilesChange={setFiles}
-                  onUpload={handleFileUpload}
-                  onDownload={handleDownload}
-                  onBack={() => setCurrentStep(2)}
-                  onNext={handleImportAndAnalyze}
-                />
-              )}
+            {currentStep === 3 && (
+              <FileSelectionStep
+                files={files}
+                selectedFiles={selectedFiles}
+                setSelectedFiles={setSelectedFiles}
+                onFilesChange={setFiles}
+                onUpload={handleFileUpload}
+                onDownload={handleDownload}
+                onBack={() => setCurrentStep(2)}
+                onNext={handleImportAndAnalyze}
+              />
+            )}
 
-              {currentStep === 4 && (
-                <ProcessingStep
-                  files={files}
-                  selectedFiles={selectedFiles}
-                  progress={processingProgress}
-                  onCopyLink={async () => {
-                    const effectiveReportId = reportId || urlReportId;
-                    if (!effectiveReportId) return false;
-                    const shareUrl = buildShareUrl(effectiveReportId);
-                    return copyToClipboard(shareUrl);
-                  }}
-                  onGoHome={() => navigate('/')}
-                />
-              )}
+            {currentStep === 4 && (
+              <ProcessingStep
+                files={files}
+                selectedFiles={selectedFiles}
+                progress={processingProgress}
+                onCopyLink={async () => {
+                  const effectiveReportId = reportId || urlReportId;
+                  if (!effectiveReportId) return false;
+                  const shareUrl = buildShareUrl(effectiveReportId);
+                  return copyToClipboard(shareUrl);
+                }}
+                onGoHome={() => navigate('/')}
+              />
+            )}
 
-              {currentStep === 5 && (
-                <CompletionStep
-                  files={files}
-                  selectedFiles={selectedFiles}
-                  onSave={handleCreateProject}
-                  onRestart={handleFinish}
-                />
-              )}
-            </div>
-          )}
+            {currentStep === 5 && (
+              <CompletionStep
+                files={files}
+                selectedFiles={selectedFiles}
+                onSave={handleCreateProject}
+                onRestart={handleFinish}
+              />
+            )}
+          </div>
         </main>
       </div>
     </div>

--- a/web_app/src/components/upload/ReportsSidebar.tsx
+++ b/web_app/src/components/upload/ReportsSidebar.tsx
@@ -1,8 +1,10 @@
-import { FileText, Calendar, ChevronRight } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { FileText, Calendar, ChevronRight, ChevronLeft, Search, X } from 'lucide-react';
 import { useReports } from '../../hooks/useReports';
 import { ApiReport } from '../../apis/report.api';
-
 import Skeleton from 'react-loading-skeleton';
+
+const PAGE_SIZE = 8;
 
 interface ReportsSidebarProps {
     selectedReportId: string | null;
@@ -10,118 +12,171 @@ interface ReportsSidebarProps {
 }
 
 export default function ReportsSidebar({ selectedReportId, onReportSelect }: ReportsSidebarProps) {
-    const { data: reportsData, isLoading } = useReports();
+    const [currentPage, setCurrentPage] = useState(1);
+    const [searchInput, setSearchInput] = useState('');
+    const [debouncedSearch, setDebouncedSearch] = useState('');
+
+    // Debounce search input — reset to page 1 on new search
+    useEffect(() => {
+        const t = setTimeout(() => {
+            setDebouncedSearch(searchInput.trim());
+            setCurrentPage(1);
+        }, 350);
+        return () => clearTimeout(t);
+    }, [searchInput]);
+
+    const { data: reportsData, isLoading, isFetching } = useReports({
+        page: currentPage,
+        page_size: PAGE_SIZE,
+        search: debouncedSearch || undefined,
+    });
 
     const formatDate = (dateString: string) => {
         if (!dateString) return 'N/A';
         const date = new Date(dateString);
         if (isNaN(date.getTime())) return 'N/A';
-        return date.toLocaleDateString('en-US', {
-            month: 'short',
-            day: 'numeric',
-            year: 'numeric'
-        });
+        return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
     };
 
-    if (isLoading) {
-        return (
-            <div className="h-full bg-white flex flex-col">
-                <div className="p-6 border-b border-sky-100 bg-sky-50/50">
-                    <Skeleton height={28} width={150} className="mb-2" />
-                    <Skeleton height={16} width={100} />
-                </div>
-                <div className="flex-1 overflow-y-auto p-4 space-y-3">
-                    {[1, 2, 3, 4, 5].map(i => (
-                        <div key={i} className="p-4 rounded-lg border border-slate-100">
-                            <Skeleton height={20} width="80%" className="mb-2" />
-                            <Skeleton height={14} width="50%" className="mb-3" />
-                            <div className="flex justify-between items-center">
-                                <Skeleton height={12} width={80} />
-                                <Skeleton height={20} width={60} borderRadius={10} />
-                            </div>
-                        </div>
-                    ))}
-                </div>
-            </div>
-        );
-    }
-
     const reports = reportsData?.reports || [];
+    const total = reportsData?.total ?? 0;
+    const totalPages = reportsData?.total_pages ?? 1;
+
+    const handlePrev = () => setCurrentPage(p => Math.max(1, p - 1));
+    const handleNext = () => setCurrentPage(p => Math.min(totalPages, p + 1));
+
+    const getBadgeClass = (status: string) => {
+        switch (status) {
+            case 'approved': return 'bg-emerald-100 text-emerald-800';
+            case 'review': return 'bg-orange-100 text-orange-800';
+            case 'process': return 'bg-blue-100 text-blue-800';
+            default: return 'bg-sky-100 text-sky-800';
+        }
+    };
 
     return (
         <div className="h-full bg-white flex flex-col">
             {/* Header */}
-            <div className="p-6 border-b border-sky-100 bg-sky-50/50">
-                <h2 className="text-xl font-bold text-slate-900 flex items-center gap-2 tracking-tight">
-                    <FileText size={24} className="text-sky-500" />
+            <div className="p-5 border-b border-sky-100 bg-sky-50/50">
+                <h2 className="text-xl font-bold text-slate-900 flex items-center gap-2 tracking-tight mb-3">
+                    <FileText size={22} className="text-sky-500" />
                     All Reports
                 </h2>
-                <p className="text-slate-500 text-sm mt-1 font-medium">
-                    {reports.length} {reports.length === 1 ? 'report' : 'reports'} available
+
+                {/* Search Input */}
+                <div className="relative group">
+                    <Search
+                        size={16}
+                        className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 group-focus-within:text-sky-500 transition-colors pointer-events-none"
+                    />
+                    <input
+                        type="text"
+                        value={searchInput}
+                        onChange={e => setSearchInput(e.target.value)}
+                        placeholder="Search by name or bank…"
+                        className="w-full pl-9 pr-8 py-2 text-sm bg-white border border-sky-200 rounded-lg
+                            focus:outline-none focus:ring-2 focus:ring-sky-500/20 focus:border-sky-400
+                            placeholder-slate-400 text-slate-800 font-medium transition-all"
+                    />
+                    {searchInput && (
+                        <button
+                            onClick={() => setSearchInput('')}
+                            className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 transition-colors"
+                        >
+                            <X size={14} />
+                        </button>
+                    )}
+                </div>
+
+                {/* Result count */}
+                <p className="text-slate-500 text-xs mt-2 font-medium">
+                    {isFetching && !isLoading && (
+                        <span className="inline-block w-2 h-2 rounded-full bg-sky-400 animate-pulse mr-1.5" />
+                    )}
+                    {total} {total === 1 ? 'report' : 'reports'}
+                    {debouncedSearch && <span className="text-sky-600"> for "{debouncedSearch}"</span>}
                 </p>
             </div>
 
             {/* Reports List */}
             <div className="flex-1 overflow-y-auto">
-                {reports.length === 0 ? (
-                    <div className="p-6 text-center">
-                        <FileText className="mx-auto text-gray-400 mb-3" size={48} />
-                        <p className="text-gray-600 font-medium">No reports yet</p>
-                        <p className="text-gray-500 text-sm mt-1">Create your first report to get started</p>
+                {isLoading ? (
+                    <div className="p-4 space-y-3">
+                        {[1, 2, 3, 4, 5].map(i => (
+                            <div key={i} className="p-4 rounded-lg border border-slate-100">
+                                <Skeleton height={18} width="75%" className="mb-2" />
+                                <Skeleton height={13} width="50%" className="mb-3" />
+                                <div className="flex justify-between items-center">
+                                    <Skeleton height={12} width={80} />
+                                    <Skeleton height={18} width={55} borderRadius={10} />
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                ) : reports.length === 0 ? (
+                    <div className="p-8 flex flex-col items-center justify-center text-center">
+                        <div className="w-14 h-14 rounded-full bg-sky-50 flex items-center justify-center mb-3">
+                            <FileText className="text-sky-300" size={28} />
+                        </div>
+                        <p className="text-slate-700 font-semibold">
+                            {debouncedSearch ? 'No results found' : 'No reports yet'}
+                        </p>
+                        <p className="text-slate-400 text-sm mt-1">
+                            {debouncedSearch
+                                ? `No reports match "${debouncedSearch}"`
+                                : 'Create your first report to get started'}
+                        </p>
+                        {debouncedSearch && (
+                            <button
+                                onClick={() => setSearchInput('')}
+                                className="mt-3 text-xs font-semibold text-sky-500 hover:text-sky-700 underline underline-offset-2"
+                            >
+                                Clear search
+                            </button>
+                        )}
                     </div>
                 ) : (
-                    <div className="p-4 space-y-2">
+                    <div className={`p-4 space-y-2 transition-opacity duration-150 ${isFetching ? 'opacity-60' : 'opacity-100'}`}>
                         {reports.map((report: ApiReport) => {
                             const status = (report as any).report_status ?? (report as any).status ?? 'draft';
-
-                            const badgeClass =
-                                status === 'approved'
-                                    ? 'bg-emerald-100 text-emerald-800'
-                                    : status === 'review'
-                                        ? 'bg-orange-100 text-orange-800'
-                                        : 'bg-sky-100 text-sky-800';
-
                             return (
                                 <button
                                     key={report.id}
                                     onClick={() => onReportSelect(report.id)}
-                                    className={`w-full text-left p-4 rounded-lg border transition-all group hover:shadow-soft ${selectedReportId === report.id
-                                        ? 'border-sky-500 bg-sky-50 shadow-sm'
-                                        : 'border-sky-100 hover:border-sky-300 bg-white'
+                                    className={`w-full text-left p-4 rounded-lg border transition-all group hover:shadow-md ${selectedReportId === report.id
+                                            ? 'border-sky-500 bg-sky-50 shadow-sm'
+                                            : 'border-sky-100 hover:border-sky-300 bg-white'
                                         }`}
                                 >
                                     <div className="flex items-start justify-between gap-2">
                                         <div className="flex-1 min-w-0">
-                                            <h3
-                                                className={`font-semibold truncate ${selectedReportId === report.id
+                                            <h3 className={`font-semibold truncate text-sm leading-snug ${selectedReportId === report.id
                                                     ? 'text-sky-900'
                                                     : 'text-slate-900 group-hover:text-sky-600'
-                                                    }`}
-                                            >
+                                                }`}>
                                                 {report.report_name || report.name}
                                             </h3>
 
                                             {report.bank_name && (
-                                                <p className="text-sm text-secondary-500 mt-1 truncate">{report.bank_name}</p>
+                                                <p className="text-xs text-slate-500 mt-0.5 truncate">{report.bank_name}</p>
                                             )}
 
-                                            <div className="flex items-center gap-2 mt-2">
-                                                <Calendar size={14} className="text-secondary-400" />
-                                                <span className="text-xs text-secondary-500">{formatDate(report.created_at)}</span>
-                                            </div>
-
-                                            <div className="mt-2">
-                                                <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${badgeClass}`}>
+                                            <div className="flex items-center gap-3 mt-2">
+                                                <div className="flex items-center gap-1 text-slate-400">
+                                                    <Calendar size={12} />
+                                                    <span className="text-xs">{formatDate(report.created_at)}</span>
+                                                </div>
+                                                <span className={`px-2 py-0.5 rounded-full text-xs font-semibold ${getBadgeClass(status)}`}>
                                                     {String(status).charAt(0).toUpperCase() + String(status).slice(1)}
                                                 </span>
                                             </div>
                                         </div>
 
                                         <ChevronRight
-                                            size={20}
-                                            className={`flex-shrink-0 transition-transform ${selectedReportId === report.id
-                                                ? 'text-sky-600 translate-x-1'
-                                                : 'text-slate-300 group-hover:text-sky-500 group-hover:translate-x-1'
+                                            size={18}
+                                            className={`flex-shrink-0 mt-0.5 transition-transform ${selectedReportId === report.id
+                                                    ? 'text-sky-600 translate-x-1'
+                                                    : 'text-slate-300 group-hover:text-sky-500 group-hover:translate-x-1'
                                                 }`}
                                         />
                                     </div>
@@ -131,6 +186,59 @@ export default function ReportsSidebar({ selectedReportId, onReportSelect }: Rep
                     </div>
                 )}
             </div>
+
+            {/* Pagination Footer */}
+            {totalPages > 1 && (
+                <div className="shrink-0 border-t border-sky-100 bg-white px-4 py-3 flex items-center justify-between gap-2">
+                    <button
+                        onClick={handlePrev}
+                        disabled={currentPage <= 1}
+                        className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold transition-all
+                            disabled:opacity-40 disabled:cursor-not-allowed
+                            bg-sky-50 text-sky-600 border border-sky-200 hover:bg-sky-100 active:scale-95"
+                    >
+                        <ChevronLeft size={14} />
+                        Prev
+                    </button>
+
+                    <div className="flex items-center gap-1">
+                        {Array.from({ length: totalPages }, (_, i) => i + 1)
+                            .filter(p => p === 1 || p === totalPages || Math.abs(p - currentPage) <= 1)
+                            .reduce<(number | 'ellipsis')[]>((acc, p, idx, arr) => {
+                                if (idx > 0 && p - (arr[idx - 1] as number) > 1) acc.push('ellipsis');
+                                acc.push(p);
+                                return acc;
+                            }, [])
+                            .map((p, idx) =>
+                                p === 'ellipsis' ? (
+                                    <span key={`e-${idx}`} className="px-1 text-slate-400 text-xs font-bold">…</span>
+                                ) : (
+                                    <button
+                                        key={p}
+                                        onClick={() => setCurrentPage(p as number)}
+                                        className={`w-7 h-7 rounded-lg text-xs font-bold transition-all active:scale-95 ${currentPage === p
+                                                ? 'bg-sky-500 text-white shadow-sm'
+                                                : 'text-slate-600 hover:bg-sky-50'
+                                            }`}
+                                    >
+                                        {p}
+                                    </button>
+                                )
+                            )}
+                    </div>
+
+                    <button
+                        onClick={handleNext}
+                        disabled={currentPage >= totalPages}
+                        className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold transition-all
+                            disabled:opacity-40 disabled:cursor-not-allowed
+                            bg-sky-50 text-sky-600 border border-sky-200 hover:bg-sky-100 active:scale-95"
+                    >
+                        Next
+                        <ChevronRight size={14} />
+                    </button>
+                </div>
+            )}
         </div>
     );
 }

--- a/web_app/src/hooks/useReports.ts
+++ b/web_app/src/hooks/useReports.ts
@@ -34,10 +34,13 @@ export function useCreateReport() {
  * Get all reports
  * GET /api/v1/reports
  */
-export function useReports(options?: { refetchInterval?: number }) {
+export function useReports(options?: { refetchInterval?: number; page?: number; page_size?: number; search?: string }) {
+  const page = options?.page ?? 1;
+  const page_size = options?.page_size ?? 10;
+  const search = options?.search ?? '';
   return useQuery({
-    queryKey: REPORTS_KEY,
-    queryFn: reportsApi.getReports,
+    queryKey: [...REPORTS_KEY, { page, page_size, search }],
+    queryFn: () => reportsApi.getReports(page, page_size, search || undefined),
     ...(options?.refetchInterval ? { refetchInterval: options.refetchInterval } : {}),
   });
 }

--- a/web_app/src/pages/DashboardPage.tsx
+++ b/web_app/src/pages/DashboardPage.tsx
@@ -5,7 +5,6 @@ import {
     CheckCircle,
     FileSearch,
     TrendingUp,
-    ArrowRight,
     Activity
 } from 'lucide-react';
 import { DashboardStats, ValuationReport, ReportStatus, PropertyType } from '../types';
@@ -286,7 +285,7 @@ export default function DashboardPage() {
                             <p className="text-sm text-slate-500 font-semibold mt-1">Track your latest generated reports and their status.</p>
                         </div>
                         <button
-                            onClick={() => navigate('/list')}
+                            onClick={() => navigate('/history')}
                             className="text-sm font-bold text-brand-600 hover:text-brand-700 bg-brand-50 hover:bg-brand-100 px-6 py-2.5 rounded-lg transition-all border border-brand-100 active:scale-95"
                         >
                             View Full History
@@ -357,15 +356,6 @@ export default function DashboardPage() {
                                 )}
                             </tbody>
                         </table>
-                    </div>
-                    {/* Empty state footer or more reports hint */}
-                    <div className="px-6 py-4 bg-sky-50/20 border-t border-sky-50 flex justify-center">
-                        <button
-                            onClick={() => navigate('/list')}
-                            className="text-slate-400 text-xs font-bold uppercase tracking-widest hover:text-slate-600 transition-colors flex items-center gap-2"
-                        >
-                            Load More Reports <ArrowRight size={14} />
-                        </button>
                     </div>
                 </div>
             </div>

--- a/web_app/src/pages/HistoryPage.tsx
+++ b/web_app/src/pages/HistoryPage.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import ReportsSidebar from '../components/upload/ReportsSidebar';
+import ReportDetailView from '../components/upload/ReportDetailView';
+
+export default function HistoryPage() {
+    const [selectedBrowseReportId, setSelectedBrowseReportId] = useState<string | null>(null);
+
+    return (
+        <div className="flex-1 flex flex-col min-h-0">
+            <div className="flex-1 min-h-0 flex flex-col bg-white rounded-xl border border-sky-100 shadow-lg overflow-hidden">
+                {/* Header */}
+                <header className="shrink-0 sticky top-0 z-40 bg-white backdrop-blur-xl border-b border-slate-100">
+                    <div className="w-full mx-auto px-2 sm:px-3 lg:px-4 py-4 md:py-6">
+                        <div className="flex items-center justify-between w-full">
+                            <h1 className="text-2xl font-bold text-slate-900 tracking-tight">Report History</h1>
+                        </div>
+                    </div>
+                </header>
+
+                {/* Main Content */}
+                <main className="flex-1 min-h-0 overflow-y-auto max-w-7xl w-full mx-auto px-2 sm:px-3 lg:px-4 py-8">
+                    <div className="grid grid-cols-1 lg:grid-cols-[380px_1fr] gap-6 min-h-full">
+                        <div className="bg-white rounded-xl shadow-lg border border-slate-200 overflow-hidden flex flex-col min-h-0">
+                            <ReportsSidebar
+                                selectedReportId={selectedBrowseReportId}
+                                onReportSelect={setSelectedBrowseReportId}
+                            />
+                        </div>
+                        <div className="bg-white rounded-xl shadow-lg border border-slate-200 overflow-hidden flex flex-col min-h-0">
+                            <ReportDetailView reportId={selectedBrowseReportId} />
+                        </div>
+                    </div>
+                </main>
+            </div>
+        </div>
+    );
+}

--- a/web_app/src/pages/ReportListPage.tsx
+++ b/web_app/src/pages/ReportListPage.tsx
@@ -1,18 +1,42 @@
-import { useState, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Search, Filter } from 'lucide-react';
+import { ArrowLeft, Search, Filter, ChevronLeft, ChevronRight, X } from 'lucide-react';
 import { useReports } from '../hooks/useReports';
 import { ApiReport } from '../apis/report.api';
 import { ValuationReport, ReportStatus, PropertyType } from '../types';
 import { formatDate } from '../utils/formatDate';
 import Skeleton from 'react-loading-skeleton';
 
+const PAGE_SIZE = 15;
+
 export default function ReportListPage() {
-    const { data: reportsData, isLoading } = useReports();
     const [searchParams] = useSearchParams();
     const navigate = useNavigate();
-    const [searchQuery, setSearchQuery] = useState('');
     const statusFilter = searchParams.get('status') as ReportStatus | null;
+
+    const [currentPage, setCurrentPage] = useState(1);
+    const [searchInput, setSearchInput] = useState('');
+    const [debouncedSearch, setDebouncedSearch] = useState('');
+
+    // Debounce search — reset to page 1 on new search
+    useEffect(() => {
+        const t = setTimeout(() => {
+            setDebouncedSearch(searchInput.trim());
+            setCurrentPage(1);
+        }, 350);
+        return () => clearTimeout(t);
+    }, [searchInput]);
+
+    // Reset page when status filter changes
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [statusFilter]);
+
+    const { data: reportsData, isLoading, isFetching } = useReports({
+        page: currentPage,
+        page_size: PAGE_SIZE,
+        search: debouncedSearch || undefined,
+    });
 
     const handleReportClick = (report: ValuationReport) => {
         switch (report.status) {
@@ -33,47 +57,29 @@ export default function ReportListPage() {
         }
     };
 
-    const filteredReports: ValuationReport[] = useMemo(() => {
-        if (!reportsData?.reports) return [];
+    // Apply client-side status filter on top of server results
+    const allReports: ValuationReport[] = (reportsData?.reports ?? [])
+        .filter(r => !statusFilter || (r.report_status || r.status) === statusFilter)
+        .map((r: ApiReport) => ({
+            id: r.id,
+            customerName: (r as any).report_name || r.customer_name || r.name || (r as any).property_owner || r.bank_name || 'Untitled Report',
+            bankName: r.bank_name || 'Unknown Bank',
+            propertyType: (r.property_type as PropertyType) || 'Residential',
+            location: r.location || 'Unknown Location',
+            status: ((r.report_status || r.status) as ReportStatus) || 'draft',
+            createdAt: new Date(r.created_at),
+            updatedAt: new Date(r.updated_at),
+            year: new Date(r.created_at).getFullYear().toString(),
+            month: (new Date(r.created_at).getMonth() + 1).toString().padStart(2, '0'),
+            files: [],
+            metadata: {} as any,
+            content: {} as any,
+            comments: [],
+            auditTrail: [],
+        }));
 
-        let reports = reportsData.reports;
-        if (statusFilter) {
-            reports = reports.filter(r => (r.report_status || r.status) === statusFilter);
-        }
-
-        let mappedReports = reports
-            .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
-            .map((r: ApiReport) => ({
-                id: r.id,
-                customerName: (r as any).report_name || r.customer_name || r.name || (r as any).property_owner || r.bank_name || 'Untitled Report',
-                bankName: r.bank_name || 'Unknown Bank',
-                propertyType: (r.property_type as PropertyType) || 'Residential',
-                location: r.location || 'Unknown Location',
-                status: ((r.report_status || r.status) as ReportStatus) || 'draft',
-                createdAt: new Date(r.created_at),
-                updatedAt: new Date(r.updated_at),
-                year: new Date(r.created_at).getFullYear().toString(),
-                month: (new Date(r.created_at).getMonth() + 1).toString().padStart(2, '0'),
-                files: [], // Not needed for simple list view
-                metadata: {} as any,
-                content: {} as any,
-                comments: [],
-                auditTrail: [],
-            }));
-
-        if (searchQuery.trim()) {
-            const query = searchQuery.toLowerCase();
-            mappedReports = mappedReports.filter(report =>
-                report.customerName.toLowerCase().includes(query) ||
-                report.bankName.toLowerCase().includes(query) ||
-                report.propertyType.toLowerCase().includes(query) ||
-                report.status.toLowerCase().includes(query) ||
-                report.location.toLowerCase().includes(query)
-            );
-        }
-
-        return mappedReports;
-    }, [reportsData, statusFilter, searchQuery]);
+    const total = reportsData?.total ?? 0;
+    const totalPages = reportsData?.total_pages ?? 1;
 
     const getStatusColor = (status: string) => {
         switch (status) {
@@ -88,6 +94,18 @@ export default function ReportListPage() {
     const pageTitle = statusFilter
         ? `${statusFilter.charAt(0).toUpperCase() + statusFilter.slice(1)} Reports`
         : 'All Reports';
+
+    const handlePrev = () => setCurrentPage(p => Math.max(1, p - 1));
+    const handleNext = () => setCurrentPage(p => Math.min(totalPages, p + 1));
+
+    // Build page numbers with ellipsis
+    const pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1)
+        .filter(p => p === 1 || p === totalPages || Math.abs(p - currentPage) <= 1)
+        .reduce<(number | 'ellipsis')[]>((acc, p, idx, arr) => {
+            if (idx > 0 && p - (arr[idx - 1] as number) > 1) acc.push('ellipsis');
+            acc.push(p);
+            return acc;
+        }, []);
 
     if (isLoading) {
         return (
@@ -107,7 +125,7 @@ export default function ReportListPage() {
                 </div>
                 <div className="bg-white rounded-xl border border-brand-100 shadow-md p-4">
                     <Skeleton height={40} className="mb-4" />
-                    <Skeleton count={5} height={60} className="mb-2" />
+                    <Skeleton count={8} height={60} className="mb-2" />
                 </div>
             </div>
         );
@@ -126,22 +144,34 @@ export default function ReportListPage() {
                     </button>
                     <div>
                         <h1 className="text-4xl font-bold text-slate-900 tracking-tight">{pageTitle}</h1>
-                        <p className="text-slate-600 font-semibold mt-1">
-                            Showing {filteredReports.length} {filteredReports.length === 1 ? 'report' : 'reports'}
+                        <p className="text-slate-500 font-semibold mt-1 text-sm">
+                            {isFetching && (
+                                <span className="inline-block w-2 h-2 rounded-full bg-sky-400 animate-pulse mr-1.5" />
+                            )}
+                            {total} {total === 1 ? 'report' : 'reports'} total
+                            {debouncedSearch && <span className="text-sky-600"> — searching "{debouncedSearch}"</span>}
                         </p>
                     </div>
                 </div>
 
                 <div className="flex items-center gap-3">
                     <div className="relative group">
-                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 group-focus-within:text-sky-500 transition-colors" size={18} />
+                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 group-focus-within:text-sky-500 transition-colors pointer-events-none" size={18} />
                         <input
                             type="text"
-                            value={searchQuery}
-                            onChange={(e) => setSearchQuery(e.target.value)}
+                            value={searchInput}
+                            onChange={e => setSearchInput(e.target.value)}
                             placeholder="Search reports..."
-                            className="pl-10 pr-4 py-2.5 bg-white border border-sky-200 rounded-lg text-base focus:ring-4 focus:ring-sky-500/10 focus:border-sky-500 outline-none w-80 shadow-sm transition-all font-medium text-slate-900 placeholder:text-slate-400"
+                            className="pl-10 pr-9 py-2.5 bg-white border border-sky-200 rounded-lg text-base focus:ring-4 focus:ring-sky-500/10 focus:border-sky-500 outline-none w-80 shadow-sm transition-all font-medium text-slate-900 placeholder:text-slate-400"
                         />
+                        {searchInput && (
+                            <button
+                                onClick={() => setSearchInput('')}
+                                className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 transition-colors"
+                            >
+                                <X size={16} />
+                            </button>
+                        )}
                     </div>
                     <button className="p-2.5 bg-white border border-sky-200 rounded-lg text-sky-600 hover:bg-sky-50 transition-all shadow-sm">
                         <Filter size={20} />
@@ -150,7 +180,7 @@ export default function ReportListPage() {
             </div>
 
             {/* Main Content Table Section */}
-            <div className="bg-white rounded-xl border border-brand-100 shadow-md overflow-hidden">
+            <div className={`bg-white rounded-xl border border-brand-100 shadow-md overflow-hidden transition-opacity duration-150 ${isFetching ? 'opacity-70' : 'opacity-100'}`}>
                 <div className="overflow-x-auto">
                     <table className="w-full">
                         <thead>
@@ -173,7 +203,7 @@ export default function ReportListPage() {
                             </tr>
                         </thead>
                         <tbody className="divide-y divide-sky-50">
-                            {filteredReports.length > 0 ? filteredReports.map((report) => (
+                            {allReports.length > 0 ? allReports.map((report) => (
                                 <tr
                                     key={report.id}
                                     className="hover:bg-brand-50/30 cursor-pointer transition-all group"
@@ -209,13 +239,25 @@ export default function ReportListPage() {
                                 </tr>
                             )) : (
                                 <tr>
-                                    <td colSpan={5} className="px-6 py-12 text-center">
+                                    <td colSpan={5} className="px-6 py-16 text-center">
                                         <div className="flex flex-col items-center justify-center text-slate-400 space-y-3">
                                             <div className="bg-slate-100 p-4 rounded-full">
                                                 <Filter size={32} />
                                             </div>
                                             <div className="text-base font-bold">No reports found</div>
-                                            <p className="text-sm">There are no reports matching the current filter.</p>
+                                            <p className="text-sm">
+                                                {debouncedSearch
+                                                    ? `No reports match "${debouncedSearch}"`
+                                                    : 'No reports match the current filter.'}
+                                            </p>
+                                            {debouncedSearch && (
+                                                <button
+                                                    onClick={() => setSearchInput('')}
+                                                    className="text-xs font-semibold text-sky-500 hover:text-sky-700 underline underline-offset-2"
+                                                >
+                                                    Clear search
+                                                </button>
+                                            )}
                                         </div>
                                     </td>
                                 </tr>
@@ -223,6 +265,62 @@ export default function ReportListPage() {
                         </tbody>
                     </table>
                 </div>
+
+                {/* Pagination Footer */}
+                {totalPages > 1 && (
+                    <div className="px-8 py-4 border-t border-sky-50 bg-white flex items-center justify-between gap-4">
+                        <p className="text-sm text-slate-500 font-medium">
+                            Page <span className="font-bold text-slate-700">{currentPage}</span> of <span className="font-bold text-slate-700">{totalPages}</span>
+                        </p>
+
+                        <div className="flex items-center gap-1.5">
+                            <button
+                                onClick={handlePrev}
+                                disabled={currentPage <= 1}
+                                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold transition-all
+                                    disabled:opacity-40 disabled:cursor-not-allowed
+                                    bg-sky-50 text-sky-600 border border-sky-200 hover:bg-sky-100 active:scale-95"
+                            >
+                                <ChevronLeft size={16} />
+                                Prev
+                            </button>
+
+                            <div className="flex items-center gap-1">
+                                {pageNumbers.map((p, idx) =>
+                                    p === 'ellipsis' ? (
+                                        <span key={`e-${idx}`} className="px-1.5 text-slate-400 text-sm font-bold">…</span>
+                                    ) : (
+                                        <button
+                                            key={p}
+                                            onClick={() => setCurrentPage(p as number)}
+                                            className={`w-9 h-9 rounded-lg text-sm font-bold transition-all active:scale-95 ${currentPage === p
+                                                    ? 'bg-sky-500 text-white shadow-sm shadow-sky-200'
+                                                    : 'text-slate-600 hover:bg-sky-50'
+                                                }`}
+                                        >
+                                            {p}
+                                        </button>
+                                    )
+                                )}
+                            </div>
+
+                            <button
+                                onClick={handleNext}
+                                disabled={currentPage >= totalPages}
+                                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold transition-all
+                                    disabled:opacity-40 disabled:cursor-not-allowed
+                                    bg-sky-50 text-sky-600 border border-sky-200 hover:bg-sky-100 active:scale-95"
+                            >
+                                Next
+                                <ChevronRight size={16} />
+                            </button>
+                        </div>
+
+                        <p className="text-sm text-slate-400 font-medium">
+                            {total} total {total === 1 ? 'report' : 'reports'}
+                        </p>
+                    </div>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION

<img width="1599" height="785" alt="image" src="https://github.com/user-attachments/assets/f6ca1c84-a818-4e75-aab7-8a91d59770c0" />

<img width="1599" height="785" alt="image" src="https://github.com/user-attachments/assets/cd4eb516-e2ae-483a-af1f-fa40532d4e8f" />


- Move Upload.tsx browse/history view to new /history route (HistoryPage)
- Remove Wizard/History toggle from Upload & Process page
- Update Dashboard "View Full History" button to navigate to /history
- Remove "Load More Reports" footer from Dashboard

- Backend: add skip/limit/search pagination to GET /reports
  - report_repo: count_all(), get_all() support skip, limit, search (regex)
  - reports.py: ?page=, ?page_size=, ?search= query params with total/total_pages in response

- Frontend: paginated API calls with page cache keys
  - report.api.ts: getReports(page, page_size, search?)
  - useReports hook: page, page_size, search options
  - ReportsSidebar: server-side pagination (8/page) + debounced search, clear button, ellipsis page numbers
  - ReportListPage: server-side pagination (15/page) + debounced search, Prev/Next, page X of Y footer