### PR TITLE
fix: restore dashboard stats accuracy after pagination

### DIFF
--- a/api/app/api/v1/reports.py
+++ b/api/app/api/v1/reports.py
@@ -119,7 +119,7 @@ async def create_report(
 async def get_reports(
     current_user: dict = Depends(get_current_user),
     page: int = Query(1, ge=1, description="Page number (1-based)"),
-    page_size: int = Query(10, ge=1, le=100, description="Number of items per page"),
+    page_size: int = Query(10, ge=1, description="Number of items per page"),
     search: Optional[str] = Query(None, description="Search term for report name or bank name"),
 ):
     """Get paginated reports for current user"""

--- a/web_app/src/pages/DashboardPage.tsx
+++ b/web_app/src/pages/DashboardPage.tsx
@@ -15,8 +15,8 @@ import { useReports } from '../hooks/useReports';
 import { ApiReport } from '../apis/report.api';
 
 export default function DashboardPage() {
-    // Poll every 5s so importing status cards appear/disappear without manual refresh
-    const { data: reportsData, isLoading } = useReports({ refetchInterval: 5000 });
+    // Fetch all reports for accurate stats (page_size=9999 bypasses pagination)
+    const { data: reportsData, isLoading } = useReports({ refetchInterval: 5000, page_size: 9999 });
     const navigate = useNavigate();
 
     const handleReportClick = (report: ValuationReport) => {
@@ -44,7 +44,7 @@ export default function DashboardPage() {
 
         const reports = reportsData.reports;
         return {
-            totalReports: reports.length,
+            totalReports: reportsData.total ?? reports.length,
             draftReports: reports.filter(r => (r.report_status || r.status) === 'draft').length,
             processReports: reports.filter(r => (r.report_status || r.status) === 'process').length,
             reviewReports: reports.filter(r => (r.report_status || r.status) === 'review').length,


### PR DESCRIPTION

<img width="1599" height="789" alt="image" src="https://github.com/user-attachments/assets/6745c73c-3e83-4ff5-83a3-59c37a6f24a0" />


- Remove le=100 cap on page_size in GET /reports (was causing 9999 to 422)
- Dashboard fetches all reports with page_size=9999 for correct status counts
- Use reportsData.total for totalReports stat