### PR TITLE
feat: integrate bank dropdown with MongoDB banks collection

### DIFF
--- a/api/app/db/seeds.py
+++ b/api/app/db/seeds.py
@@ -6,8 +6,37 @@ Creates admin user: admin@jothis.com / password123
 
 from datetime import datetime
 from bson import ObjectId
-from app.db.session import db, users, roles, user_roles
+from app.db.session import db, users, roles, user_roles, banks
 from app.core.security import hash_password
+
+
+INDIAN_BANKS = [
+    "State Bank of India (SBI)",
+    "HDFC Bank",
+    "ICICI Bank",
+    "Axis Bank",
+    "Kotak Mahindra Bank",
+    "Punjab National Bank (PNB)",
+    "Bank of Baroda",
+    "Canara Bank",
+    "Union Bank of India",
+    "Bank of India",
+    "Indian Bank",
+    "Central Bank of India",
+    "Indian Overseas Bank",
+    "UCO Bank",
+    "Bank of Maharashtra",
+    "Punjab & Sind Bank",
+    "IDBI Bank",
+    "Federal Bank",
+    "IDFC First Bank",
+    "South Indian Bank",
+    "Karur Vysya Bank",
+    "City Union Bank",
+    "Tamilnad Mercantile Bank",
+    "Karnataka Bank",
+    "Dhanlaxmi Bank",
+]
 
 
 def seed_roles():
@@ -69,11 +98,27 @@ def seed_admin_user():
     print(f"   Password: {admin_password}")
 
 
+def seed_banks():
+    """Seed the default Indian banks"""
+    now = datetime.utcnow()
+    seeded = 0
+    for bank_name in INDIAN_BANKS:
+        existing = banks.find_one({"name": {"$regex": f"^{bank_name}$", "$options": "i"}})
+        if not existing:
+            banks.insert_one({"name": bank_name, "created_at": now, "updated_at": now})
+            seeded += 1
+    if seeded:
+        print(f"✅ Seeded {seeded} banks")
+    else:
+        print("⏭️  All default banks already exist")
+
+
 def run_seeds():
     """Run all seed functions"""
     print("\n🌱 Running database seeds...\n")
     seed_roles()
     seed_admin_user()
+    seed_banks()
     print("\n✅ Seeding complete!\n")
 
 

--- a/web_app/src/components/common/ReactSelectField.tsx
+++ b/web_app/src/components/common/ReactSelectField.tsx
@@ -47,7 +47,6 @@ export const ReactSelectField: React.FC<ReactSelectFieldProps> = ({
     }
   };
 
-  console.log(options);
 
   const customStyles: StylesConfig<Option, boolean, GroupBase<Option>> = useMemo(
     () => ({

--- a/web_app/src/components/upload/ProjectNameStep.tsx
+++ b/web_app/src/components/upload/ProjectNameStep.tsx
@@ -14,34 +14,6 @@ interface ProjectNameStepProps {
   recentProjects: ProjectReport[];
 }
 
-const INDIAN_BANKS = [
-
-  "State Bank of India (SBI)",
-  "HDFC Bank",
-  "ICICI Bank",
-  "Axis Bank",
-  "Kotak Mahindra Bank",
-  "Punjab National Bank (PNB)",
-  "Bank of Baroda",
-  "Canara Bank",
-  "Union Bank of India",
-  "Bank of India",
-  "Indian Bank",
-  "Central Bank of India",
-  "Indian Overseas Bank",
-  "UCO Bank",
-  "Bank of Maharashtra",
-  "Punjab & Sind Bank",
-  "IDBI Bank",
-  "Federal Bank",
-  "IDFC First Bank",
-  "South Indian Bank",
-  "Karur Vysya Bank",
-  "City Union Bank",
-  "Tamilnad Mercantile Bank",
-  "Karnataka Bank",
-  "Dhanlaxmi Bank"
-];
 
 export default function ProjectNameStep({
   projectName,
@@ -59,7 +31,6 @@ export default function ProjectNameStep({
   });
 
   const banks = Array.isArray(banksData) ? banksData : (banksData as any)?.banks || [];
-  console.log(banks);
 
   const handleProjectNameSubmit = () => {
     if (projectName?.trim() && bankName?.trim()) {
@@ -75,21 +46,11 @@ export default function ProjectNameStep({
     });
   };
 
-  // Combine static Indian banks with dynamic banks from API
-  const allBankOptions = useMemo(() => {
-    // Get bank names from API if available
-    const apiBankNames = banks?.map((bank: any) => bank.name) || [];
-
-    // Combine both lists and remove duplicates
-    const allBanks = [...INDIAN_BANKS, ...apiBankNames];
-    const uniqueBanks = Array.from(new Set(allBanks));
-
-    // Convert to Option format
-    return uniqueBanks.map((bank) => ({
-      label: bank,
-      value: bank,
-    }));
-  }, [banks]);
+  // Map banks from API directly — managed via Bank Management page
+  const allBankOptions = useMemo(() =>
+    (banks ?? []).map((bank: any) => ({ label: bank.name, value: bank.name })),
+    [banks]
+  );
 
   const selectedBank = useMemo(() => {
     if (!bankName) return null;


### PR DESCRIPTION

<img width="1600" height="788" alt="image" src="https://github.com/user-attachments/assets/53fcf2d7-0362-4950-a729-d4600e770efe" />

<img width="1600" height="788" alt="image" src="https://github.com/user-attachments/assets/1c037e0e-7ab6-4ac8-a10f-835de0ca6fc8" />


- Seed 25 default Indian banks via seed_banks() in seeds.py (idempotent)
- Remove hardcoded INDIAN_BANKS static list from ProjectNameStep
- Dropdown now reads exclusively from the banks collection (managed via Bank Management page)
- Remove console.log debug statements from ProjectNameStep and ReactSelectField