### PR TITLE
fix: prevent auto-processing on file upload

### DIFF
--- a/web_app/src/apis/report.api.ts
+++ b/web_app/src/apis/report.api.ts
@@ -157,19 +157,17 @@ export const reportsApi = {
     }>(`/api/v1/reports/${reportId}/status`),
 
   /**
-   * Upload files to a report
-   * POST /api/v1/documents/process-multiple
+   * Upload files to a report (upload only, no processing)
+   * POST /api/v1/reports/{reportId}/files
    */
   uploadFiles: (reportId: string, files: File[]) => {
     const formData = new FormData();
     files.forEach((file) => {
       formData.append('files', file);
     });
-    formData.append('client_name', 'Client'); // Default client name required by backend
-    formData.append('report_id', reportId);
 
-    return apiClient.post<{ success: boolean; documents: any[] }>(
-      `/api/v1/documents/process-multiple`,
+    return apiClient.post<{ success: boolean; files: { id: string; file_name: string }[] }>(
+      `/api/v1/reports/${reportId}/files`,
       formData
     );
   },

--- a/web_app/src/components/Upload.tsx
+++ b/web_app/src/components/Upload.tsx
@@ -266,7 +266,7 @@ export default function Upload() {
       const response = await reportsApi.uploadFiles(effectiveReportId, newFiles);
 
       if (response && ((response as any).success || (response as any).files)) {
-        const serverFiles = (response as any).files || (response as any).documents || [];
+        const serverFiles = (response as any).files || [];
 
         setFiles((prev) =>
           prev.map((f) => {

--- a/web_app/src/pages/DashboardPage.tsx
+++ b/web_app/src/pages/DashboardPage.tsx
@@ -257,7 +257,7 @@ export default function DashboardPage() {
                         className="cursor-pointer group bg-white rounded-xl border border-brand-100 p-6 shadow-lg hover:shadow-2xl hover:shadow-brand-200/40 transition-all duration-500 relative overflow-hidden hover:border-brand-200 isolate"
                         style={{ animationDelay: `${index * 100}ms` }}
                     >
-                        <div className="flex items-start justify-between relative z-10">
+                        <div className="flex items-start justify-between gap-3 relative z-10">
                             <div className={`${card.bg} ${card.color} ${card.border} p-4 rounded-xl border group-hover:scale-110 transition-transform duration-500 shadow-md`}>
                                 {React.cloneElement(card.icon as React.ReactElement, { size: 24 })}
                             </div>


### PR DESCRIPTION
fix: prevent auto-processing on file upload, fix dashboard stat card alignment

- Switch uploadFiles API from /documents/process-multiple to /reports/{id}/files
  (upload-only endpoint) so files are no longer auto-processed on drop/browse
- Processing now only triggers when user explicitly clicks "Import & Analyze"
- Add gap-3 to dashboard stat cards to prevent "Total Reports" label overlapping
  with icon when sidebar is expanded
