### PR TITLE
feat(processing): implement cancel document processing workflow

### DIFF
--- a/api/app/api/v1/reports.py
+++ b/api/app/api/v1/reports.py
@@ -316,6 +316,106 @@ async def import_report_files(
     }
 
 
+@router.post("/reports/{report_id}/cancel")
+async def cancel_report_processing(
+    report_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    Cancel an in-progress report processing run.
+
+    Actions performed:
+    1. Revoke all in-flight / queued Celery tasks for this report's files.
+    2. Reset every original_file's processing_status → 'pending' and clear file_content.
+    3. Delete any partially-generated AI extracted content for this report.
+    4. Roll the report status back to 'process' (files are still attached, ready to re-try).
+    """
+    from app.celery_app import celery_app as _celery
+    from app.db.session import original_files as orig_col, ai_extracted_content as ai_col
+    from bson import ObjectId
+    from datetime import datetime as _dt
+
+    # --- Validate ownership ---
+    report = ReportRepository.get_by_id(report_id)
+    if not report:
+        raise HTTPException(status_code=404, detail="Report not found")
+
+    if (
+        report["user_id"] != current_user["id"]
+        and "admin" not in current_user.get("roles", [])
+    ):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    # Only allow cancel while actively processing / importing
+    allowed_statuses = {"importing", "process", "processing"}
+    if report.get("report_status") not in allowed_statuses:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot cancel a report in '{report.get('report_status')}' state. "
+                   "Only reports that are currently processing can be cancelled."
+        )
+
+    files = OriginalFileRepository.get_by_report(report_id)
+
+    revoked = []
+    for file_doc in files:
+        file_id = file_doc["id"]
+
+        # 1. Revoke the Celery task (task_id == file_id by our convention in import endpoint)
+        try:
+            _celery.control.revoke(file_id, terminate=True, signal="SIGTERM")
+            revoked.append(file_id)
+            logger.info("Revoked Celery task for file %s", file_id)
+        except Exception as exc:
+            logger.warning("Could not revoke task for file %s: %s", file_id, exc)
+
+        # 1.5 Delete the physically generated translated PDF (if any)
+        output_pdf_path = file_doc.get("output_pdf_path")
+        if output_pdf_path and os.path.exists(output_pdf_path):
+            try:
+                os.remove(output_pdf_path)
+                logger.info("Deleted physically extracted file: %s", output_pdf_path)
+            except Exception as e:
+                logger.error("Failed to delete physical extracted file %s: %s", output_pdf_path, e)
+
+        # 2. Reset this file's processing status and clear extracted content
+        orig_col.update_one(
+            {"_id": ObjectId(file_id)},
+            {
+                "$set": {
+                    "processing_status": "pending",
+                    "file_content": None,
+                    "output_pdf_path": None,
+                    "error_message": None,
+                    "total_pages": None,
+                    "current_page": None,
+                    "processed_pages": None,
+                    "summary": None,
+                    "completed_at": None,
+                    "updated_at": _dt.utcnow(),
+                }
+            },
+        )
+
+    # 3. Remove partially-generated AI content
+    deleted_ai = ai_col.delete_many({"report_id": ObjectId(report_id)})
+    logger.info(
+        "Deleted %d ai_extracted_content docs for report %s",
+        deleted_ai.deleted_count,
+        report_id,
+    )
+
+    # 4. Roll back report status → 'process' (files still attached)
+    ReportRepository.update_status(report_id, "process")
+    logger.info("Report %s rolled back to 'process' status after cancel", report_id)
+
+    return {
+        "success": True,
+        "report_id": report_id,
+        "revoked_tasks": revoked,
+        "message": "Processing cancelled. Report has been reset to its previous state.",
+    }
+
 
 @router.post("/reports/analysis")
 async def analyze_and_summarize(

--- a/web_app/src/apis/report.api.ts
+++ b/web_app/src/apis/report.api.ts
@@ -106,6 +106,15 @@ export const reportsApi = {
     ),
 
   /**
+   * Cancel in-progress processing and revert report to its previous state
+   * POST /api/v1/reports/{report_id}/cancel
+   */
+  cancelProcessing: (reportId: string) =>
+    apiClient.post<{ success: boolean; report_id: string; message: string }>(
+      `/api/v1/reports/${reportId}/cancel`
+    ),
+
+  /**
    * Analyze report (triggers new AI analysis — expensive)
    * POST /api/v1/reports/analysis
    */

--- a/web_app/src/components/Upload.tsx
+++ b/web_app/src/components/Upload.tsx
@@ -314,6 +314,22 @@ export default function Upload() {
     startPolling(effectiveReportId);
   };
 
+  const handleCancelProcessing = async () => {
+    const effectiveReportId = reportId || urlReportId;
+    if (!effectiveReportId) return;
+
+    if (pollingRef.current) clearInterval(pollingRef.current);
+
+    try {
+      await reportsApi.cancelProcessing(effectiveReportId);
+      setCurrentStep(3); // Go back to File Selection
+    } catch (error) {
+      console.error('Cancel failed:', error);
+      startPolling(effectiveReportId);
+      throw error; // Let UI know it failed
+    }
+  };
+
   const handleCreateProject = () => {
     const effectiveReportId = reportId || urlReportId;
     if (!effectiveReportId) {
@@ -471,6 +487,7 @@ export default function Upload() {
                   return copyToClipboard(shareUrl);
                 }}
                 onGoHome={() => navigate('/')}
+                onCancel={handleCancelProcessing}
               />
             )}
 

--- a/web_app/src/components/upload/ProcessingStep.tsx
+++ b/web_app/src/components/upload/ProcessingStep.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
-import { Loader2, CheckCircle2, Copy, Home } from 'lucide-react';
+import { Loader2, CheckCircle2, Copy, Home, XCircle, AlertTriangle } from 'lucide-react';
 import { UploadedFile } from './types';
+import toast from 'react-hot-toast';
 
 interface ProcessingStepProps {
     files: UploadedFile[];
@@ -8,6 +9,7 @@ interface ProcessingStepProps {
     progress?: { completed: number; total: number; percentage: number };
     onCopyLink?: () => Promise<boolean | void>;
     onGoHome?: () => void;
+    onCancel?: () => Promise<void>;
 }
 
 export default function ProcessingStep({
@@ -16,12 +18,30 @@ export default function ProcessingStep({
     progress,
     onCopyLink,
     onGoHome,
+    onCancel,
 }: ProcessingStepProps) {
     const pct = progress ? Math.round(progress.percentage) : 0;
     const done = progress?.completed ?? 0;
     const total = progress?.total ?? selectedFiles.length;
 
     const [copied, setCopied] = useState(false);
+    const [showCancelDialog, setShowCancelDialog] = useState(false);
+    const [isCancelling, setIsCancelling] = useState(false);
+
+    const handleConfirmCancel = async () => {
+        if (!onCancel) return;
+        setIsCancelling(true);
+        try {
+            await onCancel();
+            toast.success('Processing cancelled successfully.');
+            // onCancel unmounts this component, so we don't need to do much more
+        } catch (error: any) {
+            toast.error(error?.message || 'Cancel failed. Please try again.');
+        } finally {
+            setIsCancelling(false);
+            setShowCancelDialog(false);
+        }
+    };
 
 
 
@@ -111,6 +131,19 @@ export default function ProcessingStep({
                             Go to Dashboard
                         </button>
                     </div>
+
+                    {/* Cancel Processing Button */}
+                    {onCancel && (
+                        <div className="pt-2 pb-6 border-slate-100">
+                            <button
+                                onClick={() => setShowCancelDialog(true)}
+                                className="w-full flex items-center justify-center gap-2 px-6 py-2.5 rounded-xl text-red-500 font-semibold hover:bg-red-50 hover:text-red-600 transition-all border border-transparent hover:border-red-100"
+                            >
+                                <XCircle size={18} />
+                                Cancel Processing
+                            </button>
+                        </div>
+                    )}
                 </div>
 
                 {/* Per-file list */}
@@ -159,6 +192,63 @@ export default function ProcessingStep({
                 <span className="w-2 h-2 bg-sky-500 rounded-full shrink-0 animate-pulse" />
                 Processing is active — The wizard will auto-advance when done
             </p>
+
+            {/* ── Cancel Confirmation Modal ──────────────────────────────────── */}
+            {showCancelDialog && (
+                <div
+                    className="fixed inset-0 z-50 flex items-center justify-center p-4"
+                    style={{ background: 'rgba(15, 23, 42, 0.55)', backdropFilter: 'blur(4px)' }}
+                >
+                    <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full p-8 animate-in zoom-in-95 duration-200 relative">
+                        {/* Warning icon */}
+                        <div className="mx-auto mb-5 w-16 h-16 flex items-center justify-center rounded-full bg-red-50">
+                            <AlertTriangle size={32} className="text-red-500" />
+                        </div>
+
+                        <h3 className="text-xl font-bold text-slate-900 text-center mb-2">
+                            Cancel Processing?
+                        </h3>
+
+                        <p className="text-slate-500 text-center text-sm mb-1">
+                            This will{' '}
+                            <span className="font-semibold text-slate-700">
+                                stop all in-progress AI analysis
+                            </span>{' '}
+                            and revert the report to its state before processing started.
+                        </p>
+                        <p className="text-slate-500 text-center text-sm mb-7">
+                            Your uploaded files will remain attached so you can try again later.
+                        </p>
+
+                        <div className="flex flex-col gap-3">
+                            <button
+                                onClick={handleConfirmCancel}
+                                disabled={isCancelling}
+                                className="w-full flex items-center justify-center gap-2 px-6 py-3.5 rounded-xl bg-red-500 text-white font-bold hover:bg-red-600 transition-all shadow-md shadow-red-100 disabled:opacity-60 disabled:cursor-not-allowed"
+                            >
+                                {isCancelling ? (
+                                    <>
+                                        <Loader2 size={18} className="animate-spin" />
+                                        Cancelling...
+                                    </>
+                                ) : (
+                                    <>
+                                        <XCircle size={18} />
+                                        Yes, Cancel Processing
+                                    </>
+                                )}
+                            </button>
+                            <button
+                                onClick={() => setShowCancelDialog(false)}
+                                disabled={isCancelling}
+                                className="w-full px-6 py-3 rounded-xl border border-slate-200 text-slate-600 font-semibold hover:bg-slate-50 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
+                            >
+                                Keep Processing
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/web_app/src/pages/ProcessingPage.tsx
+++ b/web_app/src/pages/ProcessingPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
     Loader2,
@@ -7,12 +7,14 @@ import {
     Copy,
     Home,
     ChevronRight,
-    RefreshCw
+    RefreshCw,
+    XCircle,
+    AlertTriangle,
 } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { reportsApi } from '../apis/report.api';
 
-type StatusState = 'processing' | 'completed' | 'failed' | 'timeout';
+type StatusState = 'processing' | 'completed' | 'failed' | 'timeout' | 'cancelled';
 
 export default function ProcessingPage() {
     const { reportId } = useParams<{ reportId: string }>();
@@ -24,17 +26,22 @@ export default function ProcessingPage() {
     const [errorDetails, setErrorDetails] = useState<string | null>(null);
     const [isCopied, setIsCopied] = useState(false);
 
+    // Cancel confirmation dialog state
+    const [showCancelDialog, setShowCancelDialog] = useState(false);
+    const [isCancelling, setIsCancelling] = useState(false);
+
+    // Ref so the polling interval immediately stops when cancel fires
+    const cancelledRef = useRef(false);
+
     const pollStatus = useCallback(async () => {
-        if (!reportId) return;
+        if (!reportId || cancelledRef.current) return;
 
         try {
             const data = await reportsApi.getReportStatus(reportId);
-
             setProgress(data.progress);
 
             if (data.status === 'completed') {
                 setStatus('completed');
-                // Auto-redirect after a short delay
                 setTimeout(() => {
                     navigate(`/reports/${reportId}/edit`);
                 }, 2000);
@@ -44,21 +51,23 @@ export default function ProcessingPage() {
                 setErrorHeader('Processing failed');
                 setErrorDetails(failedFile?.error || 'An unexpected error occurred during analysis.');
             } else {
-                // Keep processing
                 setStatus('processing');
             }
         } catch (err: any) {
             console.error('Polling error:', err);
-            // Don't show error popup early per requirements
         }
     }, [reportId, navigate]);
 
     useEffect(() => {
         if (status !== 'processing') return;
 
-        const startTime = new Date().getTime();
+        const startTime = Date.now();
         const interval = setInterval(() => {
-            if (new Date().getTime() > startTime + 10 * 60 * 1000) { // 10 minutes timeout
+            if (cancelledRef.current) {
+                clearInterval(interval);
+                return;
+            }
+            if (Date.now() > startTime + 10 * 60 * 1000) {
                 setStatus('timeout');
                 clearInterval(interval);
             } else {
@@ -70,25 +79,51 @@ export default function ProcessingPage() {
     }, [status, pollStatus]);
 
     const handleCopyLink = () => {
-        const url = window.location.href;
-        navigator.clipboard.writeText(url);
+        navigator.clipboard.writeText(window.location.href);
         setIsCopied(true);
         toast.success('Link copied to clipboard');
         setTimeout(() => setIsCopied(false), 2000);
     };
 
-    const handleGoHome = () => navigate('/');
+    const handleGoHome  = () => navigate('/');
     const handleTryAgain = () => navigate('/upload');
-    const handleRefresh = () => {
+    const handleRefresh  = () => {
+        cancelledRef.current = false;
         setStatus('processing');
         pollStatus();
+    };
+
+    // ── Cancel flow ──────────────────────────────────────────────────────────
+    const handleCancelClick   = () => setShowCancelDialog(true);
+    const handleCancelDismiss = () => setShowCancelDialog(false);
+
+    const handleConfirmCancel = async () => {
+        if (!reportId) return;
+        setIsCancelling(true);
+
+        // Stop the polling loop immediately
+        cancelledRef.current = true;
+
+        try {
+            await reportsApi.cancelProcessing(reportId);
+            toast.success('Processing cancelled. Your report has been reset.');
+            setShowCancelDialog(false);
+            setStatus('cancelled');
+        } catch (err: any) {
+            console.error('Cancel failed:', err);
+            toast.error(err?.message || 'Failed to cancel. Please try again.');
+            // Re-enable polling so the user can still see progress
+            cancelledRef.current = false;
+        } finally {
+            setIsCancelling(false);
+        }
     };
 
     return (
         <div className="min-h-[80vh] flex items-center justify-center p-6">
             <div className="max-w-xl w-full bg-white rounded-3xl shadow-2xl border border-slate-100 p-8 md:p-12 text-center transition-all">
 
-                {/* STATE: PROCESSING */}
+                {/* ── STATE: PROCESSING ─────────────────────────────────────────── */}
                 {status === 'processing' && (
                     <div className="space-y-8 animate-in fade-in duration-500">
                         <div className="relative mx-auto w-24 h-24">
@@ -125,12 +160,15 @@ export default function ProcessingPage() {
                             </div>
                         </div>
 
+                        {/* Action buttons */}
                         <div className="flex flex-col sm:flex-row gap-3 pt-4">
                             <button
                                 onClick={handleCopyLink}
                                 className="flex-1 flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-sky-50 text-sky-600 font-semibold hover:bg-sky-100 transition-all border border-sky-100"
                             >
-                                {isCopied ? <CheckCircle2 size={18} className="text-green-500" /> : <Copy size={18} />}
+                                {isCopied
+                                    ? <CheckCircle2 size={18} className="text-green-500" />
+                                    : <Copy size={18} />}
                                 {isCopied ? 'Copied!' : 'Copy Link'}
                             </button>
                             <button
@@ -141,10 +179,22 @@ export default function ProcessingPage() {
                                 Go to Home
                             </button>
                         </div>
+
+                        {/* ── Cancel button ── */}
+                        <div className="pt-2 border-t border-slate-100">
+                            <button
+                                id="cancel-processing-btn"
+                                onClick={handleCancelClick}
+                                className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl text-red-500 font-semibold hover:bg-red-50 hover:text-red-600 transition-all border border-transparent hover:border-red-100"
+                            >
+                                <XCircle size={18} />
+                                Cancel Processing
+                            </button>
+                        </div>
                     </div>
                 )}
 
-                {/* STATE: COMPLETED */}
+                {/* ── STATE: COMPLETED ──────────────────────────────────────────── */}
                 {status === 'completed' && (
                     <div className="space-y-8 animate-in zoom-in-95 duration-500">
                         <div className="mx-auto w-24 h-24 bg-green-50 rounded-full flex items-center justify-center">
@@ -174,7 +224,7 @@ export default function ProcessingPage() {
                     </div>
                 )}
 
-                {/* STATE: FAILED */}
+                {/* ── STATE: FAILED ─────────────────────────────────────────────── */}
                 {status === 'failed' && (
                     <div className="space-y-8 animate-in slide-in-from-bottom-4 duration-500">
                         <div className="mx-auto w-24 h-24 bg-red-50 rounded-full flex items-center justify-center">
@@ -207,7 +257,7 @@ export default function ProcessingPage() {
                     </div>
                 )}
 
-                {/* STATE: TIMEOUT */}
+                {/* ── STATE: TIMEOUT ────────────────────────────────────────────── */}
                 {status === 'timeout' && (
                     <div className="space-y-8 animate-in fade-in duration-500">
                         <div className="mx-auto w-24 h-24 bg-amber-50 rounded-full flex items-center justify-center">
@@ -240,7 +290,101 @@ export default function ProcessingPage() {
                         </div>
                     </div>
                 )}
+
+                {/* ── STATE: CANCELLED ──────────────────────────────────────────── */}
+                {status === 'cancelled' && (
+                    <div className="space-y-8 animate-in zoom-in-95 duration-500">
+                        <div className="mx-auto w-24 h-24 bg-slate-100 rounded-full flex items-center justify-center">
+                            <XCircle size={48} className="text-slate-400" />
+                        </div>
+
+                        <div className="space-y-2">
+                            <h2 className="text-2xl font-bold text-slate-900 tracking-tight">
+                                Processing Cancelled
+                            </h2>
+                            <p className="text-slate-500">
+                                Your report has been reset to its previous state.
+                                Your uploaded files are still attached — you can try again any time.
+                            </p>
+                        </div>
+
+                        <div className="flex flex-col gap-3 pt-4">
+                            <button
+                                onClick={() => navigate(`/upload/${reportId}`)}
+                                className="w-full flex items-center justify-center gap-2 px-8 py-4 rounded-xl bg-sky-500 text-white font-bold hover:bg-sky-600 transition-all shadow-lg shadow-sky-200"
+                            >
+                                <RefreshCw size={18} />
+                                Go Back &amp; Try Again
+                            </button>
+                            <button
+                                onClick={handleGoHome}
+                                className="w-full px-4 text-sm font-medium text-slate-500 hover:text-slate-700 transition-colors"
+                            >
+                                Return to Home
+                            </button>
+                        </div>
+                    </div>
+                )}
             </div>
+
+            {/* ── Cancel Confirmation Modal ──────────────────────────────────── */}
+            {showCancelDialog && (
+                <div
+                    className="fixed inset-0 z-50 flex items-center justify-center p-4"
+                    style={{ background: 'rgba(15, 23, 42, 0.55)', backdropFilter: 'blur(4px)' }}
+                >
+                    <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full p-8 animate-in zoom-in-95 duration-200">
+                        {/* Warning icon */}
+                        <div className="mx-auto mb-5 w-16 h-16 flex items-center justify-center rounded-full bg-red-50">
+                            <AlertTriangle size={32} className="text-red-500" />
+                        </div>
+
+                        <h3 className="text-xl font-bold text-slate-900 text-center mb-2">
+                            Cancel Processing?
+                        </h3>
+
+                        <p className="text-slate-500 text-center text-sm mb-1">
+                            This will{' '}
+                            <span className="font-semibold text-slate-700">
+                                stop all in-progress AI analysis
+                            </span>{' '}
+                            and revert the report to its state before processing started.
+                        </p>
+                        <p className="text-slate-500 text-center text-sm mb-7">
+                            Your uploaded files will remain attached so you can try again later.
+                        </p>
+
+                        <div className="flex flex-col gap-3">
+                            <button
+                                id="confirm-cancel-btn"
+                                onClick={handleConfirmCancel}
+                                disabled={isCancelling}
+                                className="w-full flex items-center justify-center gap-2 px-6 py-3.5 rounded-xl bg-red-500 text-white font-bold hover:bg-red-600 transition-all shadow-md shadow-red-100 disabled:opacity-60 disabled:cursor-not-allowed"
+                            >
+                                {isCancelling ? (
+                                    <>
+                                        <Loader2 size={18} className="animate-spin" />
+                                        Cancelling...
+                                    </>
+                                ) : (
+                                    <>
+                                        <XCircle size={18} />
+                                        Yes, Cancel Processing
+                                    </>
+                                )}
+                            </button>
+                            <button
+                                id="keep-processing-btn"
+                                onClick={handleCancelDismiss}
+                                disabled={isCancelling}
+                                className="w-full px-6 py-3 rounded-xl border border-slate-200 text-slate-600 font-semibold hover:bg-slate-50 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
+                            >
+                                Keep Processing
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
<img width="1137" height="591" alt="image" src="https://github.com/user-attachments/assets/262b0e85-7190-4702-8087-9948d70bc048" />

This commit introduces a complete cancellation flow for document processing, allowing users to safely abort in-progress AI analysis and reset documents to their initial state.

Backend:
- Add `POST /api/v1/reports/{report_id}/cancel` endpoint
- Gracefully revoke actively running Celery worker tasks via `SIGTERM`
- Perform complete artifact cleanup: physical extracted PDFs deletion, MongoDB `ai_extracted_content` purge, and reset of all `original_files` processing metadata
- Roll parent report status back to 'process', ready for re-triggering

Frontend:
- Implement `cancelProcessing` interface in `reportsApi`
- Add "Cancel Processing" UI capability directly into the upload wizard steps and master `ProcessingPage`
- Add confirmation modal warning users that AI extraction will be halted
- Add routing logic to seamlessly return users back to the file selection step upon successful cancellation